### PR TITLE
fix(database): resolve “table assets already exists” and “no such table: user” errors

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,7 +6,7 @@ from flask import Flask, render_template
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import LoginManager
 from flask_mail import Mail
-from flask_migrate import Migrate, upgrade
+from flask_migrate import Migrate
 from flask_wtf.csrf import CSRFProtect, CSRFError
 
 # Local application imports
@@ -46,8 +46,6 @@ def create_app(config_class=ProductionConfig):
     
     # Register custom commands
     with app.app_context():
-        upgrade()
-
         from app.commands import init_app as init_commands
         init_commands(app)
     

--- a/app/commands.py
+++ b/app/commands.py
@@ -5,6 +5,7 @@ import os
 from werkzeug.security import generate_password_hash
 import click
 from flask.cli import with_appcontext
+import sys
 
 @click.command('refresh-user-info')
 @with_appcontext
@@ -97,7 +98,11 @@ def init_app(app):
     app.cli.add_command(setup_dev_command)
     app.cli.add_command(refresh_user_info_command)
     
-    # Setup development environment on app startup if in development mode
-    if os.environ.get('FLASK_ENV') == 'development' or app.config.get('TESTING', False):
+    # Only run dev setup if FLASK_ENV is development AND running the actual server
+    if (
+        os.environ.get('FLASK_ENV') == 'development'
+        and 'flask' in sys.argv[0]    # basic CLI check
+        and 'run' in sys.argv    # only when running `flask run`
+    ) or app.config.get('TESTING', False):
         with app.app_context():
             setup_dev_environment()


### PR DESCRIPTION
## Solution

1. **Dev Environment Setup Logic Update**  
I've implemented a new logic that ensures development-specific setup tasks - such as creating test users, only run under appropriate conditions.  
This avoids executing setup during unrelated CLI operations like `flask db upgrade`.
```python
if (
    os.environ.get('FLASK_ENV') == 'development'
    and 'flask' in sys.argv[0]
    and 'run' in sys.argv
) or app.config.get('TESTING', False):
    with app.app_context():
        setup_dev_environment()
```
### This condition triggers setup only when:
- **The app is in development mode**
  ```python
  os.environ.get('FLASK_ENV') == 'development'
  ```
- **The current process was launched using the `flask` command**
  ```python
  'flask' in sys.argv[0]
  ```
- **The specific CLI command being run is `flask run`**
  ```python
  'run' in sys.argv
  ```
- **OR: The app is running in testing mode**
  ```python
  app.config.get('TESTING', False)
  ```
This ensures setup is limited to `flask run` in development or during testing, and will not interfere with other commands, especially "flask db upgrade".

   - Related to #97  

2. **Remove direct table creation (`db.create_all()`)**  
   Calling `db.create_all()` alongside Alembic migrations leads to duplicate-table errors (e.g. “table assets already exists”). Delete any `db.create_all()` calls so that **only** Alembic manages DDL. This avoids conflicts between manual and migration-driven schema creation.
- Related to #99 

closes: #97 
closes: #99 
